### PR TITLE
Format default CORS_ORIGINS for readability

### DIFF
--- a/server/api/main.py
+++ b/server/api/main.py
@@ -9,8 +9,12 @@ import os
 
 app = FastAPI(title="Seasonal Travel Recommender API")
 
-CORS_ORIGINS = os.environ.get("CORS_ORIGINS",
-    "http://localhost:5173,http://localhost:3000,http://127.0.0.1:5173,http://127.0.0.1:3000"
+CORS_ORIGINS = os.environ.get(
+    "CORS_ORIGINS",
+    "http://localhost:5173,"
+    "http://localhost:3000,"
+    "http://127.0.0.1:5173,"
+    "http://127.0.0.1:3000"
 ).split(",")
 
 origins = [origin.strip() for origin in CORS_ORIGINS] + [


### PR DESCRIPTION
This pull request makes a small improvement to the way the default CORS origins are specified in `server/api/main.py`. The change splits the default string across multiple lines for better readability and maintainability.Split the default CORS_ORIGINS string across multiple lines to improve code readability and maintainability.